### PR TITLE
add sys/sysmacros.h for missing symbol on Debian 10

### DIFF
--- a/i2c.c
+++ b/i2c.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/ioctl.h>
 #include <linux/i2c.h>
 #include <linux/i2c-dev.h>

--- a/i2cDev.c
+++ b/i2cDev.c
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <stdarg.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 #include <epicsTypes.h>
 #include <epicsMutex.h>


### PR DESCRIPTION
Hi @dirk-zimoch 

  I added a header file into two sources, in order to remove undefined symbol on minor such as
`libi2cDev.so: undefined symbol: minor`.

  Let me know what you think. 

  @jeonghanlee